### PR TITLE
Fix resource list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,8 +90,7 @@ data "aws_iam_policy_document" "manage" {
       "iam:PassRole"
     ]
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*"
     ]
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
This pull request modifies the IAM policy document in `main.tf` to simplify resource specifications by replacing specific role ARNs with a wildcard ARN. 

### Changes to IAM Policy Document:
* Updated the `resources` field to replace two specific role ARNs (`AWSServiceRoleForAmazonEKS` and `AWSServiceRoleForAmazonEKSNodegroup`) with a wildcard ARN (`arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*`). This change broadens the scope of the policy to include all roles within the account.