### PR TITLE
add permission to tag log resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,7 @@ data "aws_iam_policy_document" "manage" {
       "logs:ListTagsForResource",
       "logs:PutRetentionPolicy",
       "logs:TagLogGroup",
+      "logs:TagResource",
     ]
     resources = [
       "arn:aws:logs:eu-central-1:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/*/cluster",


### PR DESCRIPTION
This pull request makes a minor update to the `main.tf` file by expanding the permissions in the IAM policy document for managing AWS resources.

* **IAM Policy Update**:
  * Added the `logs:TagResource` permission to the `data "aws_iam_policy_document" "manage"` block, allowing tagging of additional AWS resources. (`main.tf`, [main.tfR79](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR79))